### PR TITLE
Expose validate field

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -128,6 +128,22 @@
         // return this for chaining
         return this;
     };
+
+    /*
+     * @public
+     * Run validation against one field at a time
+     */
+
+    FormValidator.prototype.validateField = function(element) {
+        var field = this.fields[element.name] || {};
+        this.errors.length = 0;
+        if (field.hasOwnProperty('name')) {
+            field.type = element.type;
+            field.value = element.value;
+            field.checked = element.checked;
+            this._validateField(field);
+        }
+    }
     
     /*
      * @private


### PR DESCRIPTION
Hi Rick,

I noticed you have plans for inline validation in the Wiki which will be cool however for now I've exposed the validate field method so I can validate one field at a time, it clears the errors before validating the field so the errors only contain the one value.

I've used it like this: https://gist.github.com/1707845

No need to pull this if you have your inline validation plans underway, just thought I'd share what I've done.

Cheers
Chris
