### PR TITLE
Added input highlighting support

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -231,6 +231,8 @@
                 break;
             }
         }
+
+        return ruleValid;
     };
 
     /*
@@ -286,7 +288,7 @@
             param = null,
             parts = null,
             errorObj = null,
-            source = this.messages[method] || defaults.messages[method],
+            source = null,
             message = null;
         
         /*
@@ -297,6 +299,8 @@
                 param = parts[2];
         }
 
+        source = this.messages[method] || defaults.messages[method];
+        
         if (source) {
             message = source.replace('%s', field.display);
 


### PR DESCRIPTION
I've added input highlighting support to the library. Feel free to pull this if you don't already have an implementation underway.

The class that is added to the input is by default "error" but it can be changed with the setErrorClass(className) function. This is chainable like the other public setters in the library. The default is set in the defaults.errorClass property.

I've also done a bit of refactoring to break the _validate method into some smaller functions with only one responsibility. This made it easier to test and made it easier to integrate the input highlighting.
