### PR TITLE
Updated email validation rule

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -47,7 +47,7 @@
         numericRegex = /^[0-9]+$/,
         integerRegex = /^\-?[0-9]+$/,
         decimalRegex = /^\-?[0-9]*\.?[0-9]+$/,
-        emailRegex = /^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,6}$/i,
+        emailRegex = /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/i,
         alphaRegex = /^[a-z]+$/i,
         alphaNumericRegex = /^[a-z0-9]+$/i,
         alphaDashRegex = /^[a-z0-9_-]+$/i,


### PR DESCRIPTION
This previously passed invalid emails such as someone@example..com.  I replaced the rule with a (closely enough) RFC 2822 compliant one.
    
More info:
http://stackoverflow.com/q/46155/425313
http://stackoverflow.com/a/1373724/425313
http://www.regular-expressions.info/email.html
