### PR TITLE
Add a custom file_type hook (can't add it with the regular registerCallback)

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -387,7 +387,11 @@
             return (base64Regex.test(field.value));
         },
         is_file_type: function(field,type) {
-            //type is a string of comma separated values eg: is_file_type[zip] or is_file_type[jpeg,jpg,png]
+            if (field.type !== 'file') {
+                //just ignore fields that are not of type="file"
+                return true;
+            }
+
             var ext = field.value.substr( (field.value.lastIndexOf('.') +1) ),
                 typeArray = type.split(','),
                 inArray = false,


### PR DESCRIPTION
Because the registerCallback function doesn't allow a second parameter in, you can't format a hook like so:

```
custom_rule[custom_parameter]
```

like the max_length hook is defined for example.

I added a hook to check for file types before uploading. It accepts either a single extension or a comma separated string of extensions.

This is how it works:

```
{
    name: 'file',
    rules: 'is_file_type[jpg,jpeg,gif,png]'
}
```

It doesn't work with the HTML5 multiple attribute for now :)
