### PR TITLE
Add "rule" to error-object

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -43,7 +43,7 @@
      * Define the regular expressions that will be used
      */
 
-    var ruleRegex = /^(.+?)\[(.+)\]$/,
+    var ruleRegex = /^(.+)\[(.+)\]$/,
         numericRegex = /^[0-9]+$/,
         integerRegex = /^\-?[0-9]+$/,
         decimalRegex = /^\-?[0-9]*\.?[0-9]+$/,
@@ -257,7 +257,8 @@
                 this.errors.push({
                     id: field.id,
                     name: field.name,
-                    message: message 
+                    message: message,
+                    rule: method
                 });
 
                 // Break out so as to not spam with validation errors (i.e. required and valid_email)


### PR DESCRIPTION
Sometimes it's desirable to know which rule failed (and not just the error message). In this case I think it's good to add a `rule` property which contains the method name that failed.

Arbitrary rules are passed without the `callback_` prefix.
