### PR TITLE
Clarified that validate.js is licenced under the MIT licence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,9 @@
+validate.js is licenced under the MIT licence
+The text of this licence is provided below
+
+MIT License
+-----------
+
 Copyright (C) 2011 by Rick Harrison, http://rickharrison.me
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
only a small change to clarify the licence
_(some companies need definitive clarification of the licence type to allow a library to be used)_
