### PR TITLE
Fixed issue #49

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -212,10 +212,10 @@
         var rules = field.rules.split('|');
 
         /*
-         * If the value is null and not required, we don't need to run through validation
+         * If the value is null and not required, we don't need to run through validation, unless the rule is a callback, but then only if the value is not null
          */
-
-        if (field.rules.indexOf('required') === -1 && (!field.value || field.value === '' || field.value === undefined)) {
+        
+        if ( (field.rules.indexOf('required') === -1 && (!field.value || field.value === '' || field.value === undefined)) && (field.rules.indexOf('callback_') === -1 || field.value === null) ) {
             return;
         }
 


### PR DESCRIPTION
Fixed the case where "required" rule is not needed but a callback must still be run. Previously the callback was ignored if "required" was not present. This was reported as issue #49:
https://github.com/rickharrison/validate.js/issues/49
