### PR TITLE
Fixes submit on error

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -110,9 +110,7 @@
 
         this.form.onsubmit = (function(that) {
             return function(event) {
-                try {
-                    return that._validateForm(event);
-                } catch(e) {}
+                return that._validateForm(event);
             }
         })(this);
     },
@@ -188,7 +186,12 @@
         }
 
         if (typeof this.callback === 'function') {
-            this.callback(this.errors, event);
+            try {
+                this.callback(this.errors, event);
+            }
+            catch (e) {
+                console.log(e);
+            }
         }
 
         if (this.errors.length > 0) {


### PR DESCRIPTION
Fixes issue #40. When the validation callback throws an error, `_validateForm` breaks before calling `event.preventDefault()` but the `onSubmit` handler catches and suppresses the error. This makes the form submit for seemingly no reason. This pull request moves the `try...catch` so that an invalid form will not submit when the callback throws an error.
