### PR TITLE
Only validate fields that actually exist

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -177,13 +177,10 @@
                     field.type = (element.length > 0) ? element[0].type : element.type;
                     field.value = attributeValue(element, 'value');
                     field.checked = attributeValue(element, 'checked');
+                    
+                    // Run through the rules for each field.
+                    this._validateField(field);
                 }
-
-                /*
-                 * Run through the rules for each field.
-                 */
-
-                this._validateField(field);
             }
         }
 


### PR DESCRIPTION
Currently with a validator like

``` javascript
{
  name: 'user[first_name]',
  rules: 'required|max_length[30]'
}
```

the validator will run against this object even if the `user[first_name]` field doesn't actually exist in the form at the time of the validation.

Perhaps there is well thought reasoning for this, but I thought I'd propose a different behavior, to **ignore validations against nonexistent form fields**.

---

I work in applications that contain users with varying permissions. A user account form for an admin will have many more fields present than that same form for a less privileged user. It's cumbersome to wrap validation for such conditionally rendered fields in conditionals to test for each field's presence to decide whether or not it should be added to the list of validators to send to validate.js.
