### PR TITLE
 callback rules may have a parameter

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -255,16 +255,8 @@
                 method = method.substring(9, method.length);
 
                 if (typeof this.handlers[method] === 'function') {
-                    if (this.handlers[method].apply(this, [field.value]) === false) {
-                        if (param === undefined) {
-                            if (this.handlers[method].apply(this, [field.value]) === false) {
-                                failed = true;
-                            }
-                        } else {
-                            if (this.handlers[method].apply(this, [field.value, param]) === false) {
-                                failed = true;
-                            }
-                        }
+                    if (this.handlers[method].apply(this, [field.value, param]) === false) {
+                        failed = true;
                     }
                 }
             }


### PR DESCRIPTION
It is now possible to use parameters with custom callbacks. In this case, the callback function needs two arguments, of course.
