### PR TITLE
Default Text in Text Boxes

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -16,6 +16,7 @@
         messages: {
             required: 'The %s field is required.',
             matches: 'The %s field does not match the %s field.',
+            default: 'The %s field is still set to default, please change',
             valid_email: 'The %s field must contain a valid email address.',
             valid_emails: 'The %s field must contain all valid email addresses.',
             min_length: 'The %s field must be at least %s characters in length.',
@@ -306,7 +307,13 @@
 
             return (value !== null && value !== '');
         },
-
+        
+        default: function(field,defaultName){
+			return field.value !== defaultName;
+			
+		
+		},
+        
         matches: function(field, matchName) {
             var el = this.form[matchName];
 


### PR DESCRIPTION
Added in the ability to set defaults in text Boxes.  When the validator runs it will check to make sure the text box has been changed. To use under rules have default[default Text]
