### PR TITLE
Added 4 new rules

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -27,10 +27,14 @@
             alpha_numeric: 'The %s field must only contain alpha-numeric characters.',
             alpha_dash: 'The %s field must only contain alpha-numeric characters, underscores, and dashes.',
             numeric: 'The %s field must contain only numbers.',
+            numeric_or_empty: 'The %s field must be empty or contain only numbers.',
             integer: 'The %s field must contain an integer.',
+            integer_or_empty: 'The %s field must be empty or contain an integer.',
             decimal: 'The %s field must contain a decimal number.',
+            decimal_or_empty: 'The %s field must be empty or contain a decimal number.',
             is_natural: 'The %s field must contain only positive numbers.',
             is_natural_no_zero: 'The %s field must contain a number greater than zero.',
+            is_natural_or_empty: 'The %s field must be empty or contain only positive numbers.',
             valid_ip: 'The %s field must contain a valid IP.',
             valid_base64: 'The %s field must contain a base64 string.',
             valid_credit_card: 'The %s field must contain a vaild credit card number',
@@ -388,12 +392,33 @@
         numeric: function(field) {
             return (decimalRegex.test(field.value));
         },
+        
+        numeric_or_empty: function(field) {
+            if(field.value.length == 0){
+                return true;
+            }
+            return (decimalRegex.test(field.value));
+        },
 
         integer: function(field) {
             return (integerRegex.test(field.value));
         },
+        
+        integer_or_empty: function(field) {
+            if(field.value.length == 0){
+                return true;
+            }
+            return (integerRegex.test(field.value));
+        },
 
         decimal: function(field) {
+            return (decimalRegex.test(field.value));
+        },
+        
+        decimal_or_empty: function(field) {
+            if(field.value.length == 0){
+                return true;
+            }
             return (decimalRegex.test(field.value));
         },
 
@@ -403,6 +428,13 @@
 
         is_natural_no_zero: function(field) {
             return (naturalNoZeroRegex.test(field.value));
+        },
+        
+        is_natural_or_empty: function(field) {
+            if(field.value.length == 0){
+                return true;
+            }
+            return (naturalRegex.test(field.value));
         },
 
         valid_ip: function(field) {


### PR DESCRIPTION
added 4 new rules which I needed in my customer's use of validate.js:
- numeric_or_empty
- integer_or_empty
- decimal_or_empty
- is_natural_or_empty

The use case for this was that the customer was collecting prices in a field. I had used is_natural (they wanted whole positive numbers only) and where there was no data available (i.e. "unknown or not applicable") the users were entering zero. This was skewing the customer's analysis because the "zero" value looked like an actual zero price (thereby lowering average prices).

Having created is_natural_or_empty I thought it would be useful to have versions for the other number-related checks.
