### PR TITLE
Made currently validating field accessible to callbacks.

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -277,6 +277,18 @@
             }
 
             /*
+             * If the rule starts with !, only validate if not empty.
+             */
+
+            if (method[0] === '!') {
+              if (!field.value || field.value === '' || field.value === undefined) {
+                continue;
+              }
+              // Strip the ! and carry on
+              method = method.substring(1, method.length);
+            }
+
+            /*
              * If the hook is defined, run it to find any validation errors
              */
 


### PR DESCRIPTION
Adds a 'validating' variable used to make the current field accessible to callbacks. Necessary to implement a 'don't validate if not required clause' in the callback.

That said, maybe it's worth implementing a switch in the rules string (I think an exclamation mark would be ideal), that makes running the callback conditional on an empty field.

For example
['required|callback_foo'] = callback foo will always be called
['!callback_foo'] = callback foo will always be called
['other_rules|callback_foo'] = callback foo will only be called if the field is not empty

**edit: Actually probably better the other way around to prevent breaking backwards compatibility of api, so:**
['required|callback_foo'] = callback foo will always be called
['callback_foo'] = callback foo will always be called
['other_rules|!callback_foo'] = callback foo will only be called if the field is not empty

Happy to implement.
