### PR TITLE
Modified `FormValidator.prototype._validateField()` to support allowing custom messages.

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -299,7 +299,7 @@
 
             if (failed) {
                 // Make sure we have a message for this rule
-                var source = this.messages[method] || defaults.messages[method],
+                var source = this.messages[field.name + '.' + method] || this.messages[method] || defaults.messages[method],
                     message = 'An error has occurred with the ' + field.display + ' field.';
 
                 if (source) {


### PR DESCRIPTION
Modified `FormValidator.prototype._validateField()` to support allowing custom messaging on a per field/rule basis. For instance, you can now use the following syntax to target applying a unique validation error messaging to the field `fieldName` when it fails `required`:

``` js
// initiate validator with single required rule
var validator = new FormValidator(
    'form-identifier', 
    { name: 'fieldName', display: 'your field name', rules: 'required' },
    function(errors, evt) { }
);

// set custom error message display for fieldName input field and required rule
validator.setMessage('fieldName.required', 'This field is required, yo');
```

When using `setMessage()`, the newly supported format is `fieldName`.`validationRule`. This allows you to uniquely target individual field/rule combos for error messaging. Very useful if you want to give more instruction/detail to a user.

This scratches my itch for overriding messaging on a low level. Hope others find this helpful!
