### PR TITLE
Export FormValidator as a CommonJS module

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -529,3 +529,10 @@
     window.FormValidator = FormValidator;
 
 })(window, document);
+
+/*
+ * Export as a CommonJS module
+ */
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = FormValidator;
+}


### PR DESCRIPTION
Just a quick few lines to export FormValidator as a CommonJS module which is really helpful for using FormValidator via Browserify without the need to shim it.
