### PR TITLE
Make the valid emails check more permissive of whitespace

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -416,7 +416,7 @@
         },
 
         valid_emails: function(field) {
-            var result = field.value.split(",");
+            var result = field.value.split(/\s*,\s*/g);
 
             for (var i = 0, resultLength = result.length; i < resultLength; i++) {
                 if (!emailRegex.test(result[i])) {


### PR DESCRIPTION
Use a regular expression to split the field value so that if the user
puts a space before or after the comma then the validation doesn’t fail.
Fixes #129