### PR TITLE
Fix IE8 bug

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -119,6 +119,7 @@
 
         this.form.onsubmit = (function(that) {
             return function(evt) {
+                evt = evt || window.event;
                 try {
                     return that._validateForm(evt) && (_onsubmit === undefined || _onsubmit());
                 } catch(e) {}


### PR DESCRIPTION
The onsubmit event handler threw an ‘object expected’ error because the
event object is not provided to callbacks in IE8, tweaked to fallback
to using global event object.
Fixes #131