### PR TITLE
Add example of passing element names as array to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ validate.js is a lightweight JavaScript form validation library inspired by Code
         name: 'minlength',
         display: 'min length',
         rules: 'min_length[8]'
+    }, {
+        names: ['fname', 'lname'],
+        rules: 'required|alpha'
     }], function(errors) {
         if (errors.length > 0) {
             // Show the errors


### PR DESCRIPTION
Currently there's no way for a user to know this is possible without reading the source.