### PR TITLE
Allow multiple error messages without comprimising existing API

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -348,16 +348,22 @@
                     }
                 }
 
-                this.errors.push({
+                var existingError;
+                for (var i = 0; i < this.errors.length; i += 1) {
+                    if (field.id === this.errors[i].id) {
+                        existingError = this.errors[i];
+                    }
+                }
+                var errorObject = existingError || {
                     id: field.id,
                     element: field.element,
                     name: field.name,
                     message: message,
+                    messages: [],
                     rule: method
-                });
-
-                // Break out so as to not spam with validation errors (i.e. required and valid_email)
-                break;
+                };
+                errorObject.messages.push(message);
+                if (!existingError) this.errors.push(errorObject);
             }
         }
     };


### PR DESCRIPTION
We needed a way to access all the validation errors for a given field. The existing code breaks out of the error processing as soon as it finds one error, which makes this impossible. This PR, allows the current behavior to work as originally intended (the message contains the first error message), but also populates the error object with a messages array that returns all error messages for the field.