### PR TITLE
Make file type check case-insensitive

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -558,7 +558,7 @@
                 len = typeArray.length;
 
             for (i; i < len; i++) {
-                if (ext == typeArray[i]) inArray = true;
+                if (ext.toUpperCase() == typeArray[i].toUpperCase()) inArray = true;
             }
 
             return inArray;


### PR DESCRIPTION
Normalizes case during comparison so that the valid extensions array is case-insensitive.