### PR TITLE
Add support to reset the new validation rules after the initialization

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -156,6 +156,48 @@
         // return this for chaining
         return this;
     };
+    
+    /*
+     * @public
+     *
+     * @param fields - Array - [{
+     *     name: The name of the element (i.e. <input name="myField" />)
+     *     display: 'Field Name'
+     *     rules: required|matches[password_confirm]
+     * }]
+     * Sets new custom validation rules set
+     */
+
+    FormValidator.prototype.setRules = function(fields) {
+        this.fields = {};
+        
+        for (var i = 0, fieldLength = fields.length; i < fieldLength; i++) {
+            var field = fields[i];
+
+            // If passed in incorrectly, we need to skip the field.
+            if ((!field.name && !field.names) || !field.rules) {
+                console.warn('validate.js: The following field is being skipped due to a misconfiguration:');
+                console.warn(field);
+                console.warn('Check to ensure you have properly configured a name and rules for this field');
+                continue;
+            }
+
+            /*
+             * Build the master fields array that has all the information needed to validate
+             */
+
+            if (field.names) {
+                for (var j = 0, fieldNamesLength = field.names.length; j < fieldNamesLength; j++) {
+                    this._addField(field, field.names[j]);
+                }
+            } else {
+                this._addField(field, field.name);
+            }
+        }
+
+        // return this for chaining
+        return this;
+    };
 
     /*
      * @public


### PR DESCRIPTION
Add functionality to validate.js which will now support to reset validation rules.

Let say user init the form validator by using codes like:
```javascript
    var validator = new FormValidator('example_form', [{
        name: 'req',
        display: 'required',
        rules: 'required'
    }, {
        name: 'alphanumeric',
        rules: 'alpha_numeric'
    }, {
        name: 'password',
        rules: 'required'
    }, {
        name: 'password_confirm',
        display: 'password confirmation',
        rules: 'required|matches[password]'
    }, {
        name: 'email',
        rules: 'valid_email'
    }, {
        name: 'minlength',
        display: 'min length',
        rules: 'min_length[8]'
    }, {
        names: ['fname', 'lname'],
        rules: 'required|alpha'
    }], function(errors) {
        if (errors.length > 0) {
            // Show the errors
        }
    });
```

Now user can override rules by simply calling:

```javascript
    validator.setRules([{
        name: 'req',
        display: 'required',
        rules: 'required'
    }, {
        name: 'alphanumeric',
        rules: 'alpha_numeric'
    }, {
        name: 'password',
        rules: 'required'
    }, {
        name: 'password_confirm',
        display: 'password confirmation',
        rules: 'required|matches[password]'
    }, {
        name: 'email',
        rules: 'valid_email'
    }]);
```