### PR TITLE
use field.name for existing error check instead of using field.id

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -351,7 +351,7 @@
 
                 var existingError;
                 for (j = 0; j < this.errors.length; j += 1) {
-                    if (field.name === this.errors[j].name) {
+                    if (field.name === this.errors[j].name && field.id === this.errors[j].id) {
                         existingError = this.errors[j];
                     }
                 }

--- a/validate.js
+++ b/validate.js
@@ -351,7 +351,7 @@
 
                 var existingError;
                 for (j = 0; j < this.errors.length; j += 1) {
-                    if (field.id === this.errors[j].id) {
+                    if (field.name === this.errors[j].name) {
                         existingError = this.errors[j];
                     }
                 }


### PR DESCRIPTION
# fix existingError check
## related issue
#173
## what to fix

field.id is empty in case below, so you can't get all error in some case.
- checkbox
- radio
- textarea
- No id attribute is set
## change

use field.name for check instead of using field.id
