### PR TITLE
Declare variable ‘ruleLength’

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -318,7 +318,7 @@
      */
 
     FormValidator.prototype._validateField = function(field) {
-        var i, j,
+        var i, j, ruleLength,
             rules = field.rules.split('|'),
             indexOfRequired = field.rules.indexOf('required'),
             isEmpty = (!field.value || field.value === '' || field.value === undefined);


### PR DESCRIPTION
Fixes the issue when using validate.js in ES6 modules, which are implicitly in strict mode.
Validator failed silently.
Only when calling the method _validateForm() an error was thrown.