### PR TITLE
Loop through radio/checkbox arrays to properly add an ID to each erro…

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -270,6 +270,14 @@
 
                 if (element && element !== undefined) {
                     field.id = attributeValue(element, 'id');
+
+                    if (element.length > 1) {
+                        // console.log('---ISARRAY---')
+                        for (var i = element.length - 1; i >= 0; i--) {
+                            // console.log(element[i])
+                            field.id = element[i].getAttribute('id')
+                        }
+                    }
                     field.element = element;
                     field.type = (element.length > 0) ? element[0].type : element.type;
                     field.value = attributeValue(element, 'value');


### PR DESCRIPTION
I noticed in my usage that lists of radio or checkboxes had ID's set as undefined in the validation array. This loops through these lists and adds this ID into the validation and treats each list as their own error object.